### PR TITLE
Server Launcher/Application Loader Visual Improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ const app = require('./src/apps/main').app                      // Creates Ideox
 app.listen(cfg.server.port||3080, ()=> {                        // Listens on environment set port
     console.log(`\n\n`)
     console.log(`${c.greenBright('⦿')}  ${c.bold.italic(cfg.server.name + ' Main Server')}`)
+    if (process.env.NODE_ENV != 'production')
+        console.log(c.magentaBright.italic(`\t(DEV) Now you can visit the website in testing mode at http://${cfg.server.ip||'localhost'}:${cfg.server.port||3080}/`))
     console.log(`\tStatus: ${c.greenBright('online')}`)
     console.log(`\tNetwork:`)
     console.log(`\t\tIP: ${c.keyword('orange')(cfg.server.ip||'localhost')}`)

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ app.listen(cfg.server.port||3080, ()=> {                        // Listens on en
     console.log(`\tPID: ${process.pid}`)
     console.log(`\tLoaded Apps:`)
     cfg.server.apps.forEach(_app => {
-        console.log(`\t\t${_app}: ${c.bgGreenBright(' ✔ OK ')}`)
+        console.log(`\t\t${_app}: ${c.bgGreen(' ✔ OK ')}`) // TODO: use request module to "ping" server
     })
     console.log(`\tLogs:`)
 }) 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 // Load local .env config if not prod
 process.env.NODE_ENV != 'production'? require('dotenv').config():{}
 
+const c = require('chalk')                                      // Terminal coloring
+
 // Config
 try {
     global.cfg = require('./config.json')
@@ -11,5 +13,16 @@ try {
 const app = require('./src/apps/main').app                      // Creates Ideoxan Server
 
 app.listen(cfg.server.port||3080, ()=> {                        // Listens on environment set port
-    console.log(`${cfg.server.name} Server Online`)
+    console.log(`\n\n`)
+    console.log(`${c.greenBright('⦿')}  ${c.bold.italic(cfg.server.name + ' Main Server')}`)
+    console.log(`\tStatus: ${c.greenBright('online')}`)
+    console.log(`\tNetwork:`)
+    console.log(`\t\tIP: ${c.keyword('orange')(cfg.server.ip||'localhost')}`)
+    console.log(`\t\tPort: ${c.keyword('orange')(cfg.server.port||3080)}`)
+    console.log(`\tPID: ${process.pid}`)
+    console.log(`\tLoaded Apps:`)
+    cfg.server.apps.forEach(_app => {
+        console.log(`\t\t${_app}: ${c.bgGreenBright(' ✔ OK ')}`)
+    })
+    console.log(`\tLogs:`)
 }) 

--- a/src/apps/main.js
+++ b/src/apps/main.js
@@ -47,7 +47,7 @@ mongoose.connect(cfg.server.mongo || "mongodb://localhost:27017/ix", {
 
 mongoose.set('debug', (coll, method) => {                       // Logging (DB)
     console.log([
-        '[', c.grey(new Date().toISOString()), ']',
+        '\t\t[', c.grey(new Date().toISOString()), ']',
         c.bold('[DATABASE]'),
         method.toUpperCase(),
         'web', '→', coll
@@ -71,7 +71,7 @@ app.use(cfg.server.mountPoints.static, express.static('static', {
 
 app.use(morgan((tokens, req, res) => {                          // Logging
     return [
-        '[', c.grey(tokens['date'](req, res, 'iso')), ']',
+        '\t\t[', c.grey(tokens['date'](req, res, 'iso')), ']',
         c.bold('[SERVER]'),
         tokens['method'](req, res),
         '(', coloredResponse(tokens['status'](req, res)), '|', tokens['response-time'](req, res), 'ms)',


### PR DESCRIPTION
<!-- 
    If your request is a work in progress, not fully complete, or can not be reviewed by the Ideoxan Dev Team yet, please select the Draft option.
    
    It takes us longer to review, verify, and merge large pull requests. If your PR deals with multiple categories, we suggest you split them up into smaller groups of commits
    
    Your PR, unless you are a bot of course, will be immediately be rejected if there is a forced commit added to the PR.
    
    We suggest you know a little bit about markdown so you can fill this PR request out properly. https://guides.github.com/features/mastering-markdown/
    
    If you have any questions about opening a pull request, reach out to us! We will be happy to help. 
-->

## Description
This PR adds a newer and cleaner server launch status that clearly identifies what port, IP, and PID the server is using. It also shows a nice little message when not in production mode on how to visit the server.

## Related Issues and Files
- `index.js`
- `src/apps/main.js`

## PR Type
*This pull request is a/deals with...*
- [ ] Fix (Bug/Security/Otherwise)
- [ ] Optimization
- [ ] Documentation Update
- [X] Enhancement/Feature Addition
- [ ] Other

## PR Category
*This pull request modifies at least one of the following...*
- [X] Server Backend (`/src/`)
- [ ] Curriculum Files (`/static/curriculum/`)
- [ ] Website Front End (`/views/`, `/static/css/`, `/static/js/`)
- [ ] Editor (`/views/editor.ejs`, `/static/js/editor.js`)
- [ ] Other Static Files (`/static/`)
- [ ] Organization/Dependencies/Quality of Life/Other

## Misc.
*By creating this pull request you agree to the following...*
- [X] I have read the [Ideoxan Repository Code of Conduct](https://github.com/ideoxan/ideoxan/blob/master/CODE_OF_CONDUCT.md)
- [X] I have read the [Ideoxan Repository Contributing Guidelines](https://github.com/ideoxan/ideoxan/blob/master/CONTRIBUTING.md)
- [X] I read and agree to the [Terms and Conditions](https://ideoxan.com/tos) and [Privacy Policy](https://ideoxan.com/privacy) of Ideoxan
